### PR TITLE
Add tests and GitHub Actions, update YouTube parser

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,26 @@
+name: PHP Tests
+
+on:
+  push:
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'tests/**'
+  pull_request:
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'tests/**'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-php@v3
+        with:
+          php-version: '8.1'
+      - run: composer install --prefer-dist --no-progress --no-interaction
+      - run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "youtube/parser-php",
+    "description": "YouTube parser library for PHP",
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "^10.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "YoutubeParser\\": "youtube-parser/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "YoutubeParser\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/YoutubeTest.php
+++ b/tests/YoutubeTest.php
@@ -1,0 +1,50 @@
+<?php
+use PHPUnit\Framework\TestCase;
+require_once __DIR__.'/../youtube-parser/youtube.php';
+
+class YoutubeTest extends TestCase {
+    public function testValidWatchUrl() {
+        $yt = new Youtube('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+        $this->assertTrue($yt->valid());
+        $this->assertEquals('dQw4w9WgXcQ', $yt->get_id());
+    }
+
+    public function testValidEmbedUrl() {
+        $yt = new Youtube('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ');
+        $this->assertTrue($yt->valid());
+        $this->assertEquals('dQw4w9WgXcQ', $yt->get_id());
+    }
+
+    public function testValidShortUrl() {
+        $yt = new Youtube('https://youtu.be/dQw4w9WgXcQ?si=abc');
+        $this->assertTrue($yt->valid());
+        $this->assertEquals('dQw4w9WgXcQ', $yt->get_id());
+    }
+
+    public function testShortsUrl() {
+        $yt = new Youtube('https://www.youtube.com/shorts/dQw4w9WgXcQ');
+        $this->assertTrue($yt->valid());
+        $this->assertEquals('dQw4w9WgXcQ', $yt->get_id());
+    }
+
+    public function testTimeParameter() {
+        $yt = new Youtube('https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=22s');
+        $this->assertEquals('22', $yt->get_time());
+    }
+
+    public function testTimeFragment() {
+        $yt = new Youtube('https://www.youtube.com/watch?v=dQw4w9WgXcQ#t=22');
+        $this->assertEquals('22', $yt->get_time());
+    }
+
+    public function testList() {
+        $yt = new Youtube('https://youtu.be/dQw4w9WgXcQ?list=RDQMKKCg_1xxtsQ#t=22');
+        $this->assertEquals('RDQMKKCg_1xxtsQ', $yt->get_list());
+    }
+
+    public function testInvalid() {
+        $yt = new Youtube('https://www.example.com/watch?v=dQw4w9WgXcQ');
+        $this->assertFalse($yt->valid());
+        $this->assertNull($yt->get_id());
+    }
+}

--- a/youtube-parser/youtube.php
+++ b/youtube-parser/youtube.php
@@ -41,10 +41,11 @@ class Youtube {
 	}
 	
 	
-	private function is_short_format() {
-		$re = "/\/(e|v)\/[a-zA-Z0-9_-]{11}$/";
-		return preg_match($re ,$this->youtube_link);
-	}
+        private function is_short_format() {
+                $path = $this->get_part("path");
+                $re = "/\/(e|v|shorts|clip|live)\/[a-zA-Z0-9_-]{11}$/";
+                return preg_match($re, $path);
+        }
 
 
 	private function get_part($part) {


### PR DESCRIPTION
## Summary
- update the parser to recognise `shorts`, `clip` and `live` URLs
- convert line endings and modernise the code
- create PHPUnit tests covering basic functionality
- add GitHub Actions pipeline to run tests on push or PR
- include composer configuration and phpunit setup

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6878ee59b5a0832a8d98571a71d06b05